### PR TITLE
feat: improve libsoundio homebrew bottle support

### DIFF
--- a/nix/pool/feature-recipe/exp/feature_libsoundio-homebrew.sh
+++ b/nix/pool/feature-recipe/exp/feature_libsoundio-homebrew.sh
@@ -1,8 +1,6 @@
-if [ ! "$_LIBSOUNDIO-HOMEBREW_INCLUDED_" = "1" ]; then
-_LIBSOUNDIO-HOMEBREW_INCLUDED_=1
+if [ ! "$_LIBSOUNDIO_HOMEBREW_INCLUDED_" = "1" ]; then
+_LIBSOUNDIO_HOMEBREW_INCLUDED_=1
 
-# TODO
-# ./nix/pool/artefact/homebrew-get-bottle.sh -n libsoundio --list
 feature_libsoundio-homebrew() {
 	FEAT_NAME="libsoundio-homebrew"
 	FEAT_LIST_SCHEMA="latest:binary"
@@ -14,41 +12,24 @@ feature_libsoundio-homebrew() {
 feature_libsoundio-homebrew_latest() {
 	FEAT_VERSION="latest"
 
-	if [ "$STELLA_CURRENT_PLATFORM" = "darwin" ]; then
-		if [ "$STELLA_CURRENT_CPU_FAMILY" = "intel" ]; then
-			FEAT_BINARY_URL_x64=""
-			FEAT_BINARY_URL_FILENAME_x64="libsoundio-homebrew-macos-amd64-${FEAT_VERSION}.zip"
-			FEAT_BINARY_URL_PROTOCOL_x64="HOMEBREW_BOTTLE"
-		fi
-		if [ "$STELLA_CURRENT_CPU_FAMILY" = "arm" ]; then
-			FEAT_BINARY_URL_x64="https://github.com/fathyb/libsoundio-homebrew/releases/download/v0.0.3/libsoundio-homebrew.macos-arm64.zip"
-			FEAT_BINARY_URL_FILENAME_x64="libsoundio-homebrew-macos-arm64-${FEAT_VERSION}.zip"
-			FEAT_BINARY_URL_PROTOCOL_x64="HTTP_ZIP"
-		fi
-	fi
-	if [ "$STELLA_CURRENT_PLATFORM" = "linux" ]; then
-		if [ "$STELLA_CURRENT_CPU_FAMILY" = "intel" ]; then
-			FEAT_BINARY_URL_x64="https://github.com/fathyb/libsoundio-homebrew/releases/download/v0.0.3/libsoundio-homebrew.linux-amd64.zip"
-			FEAT_BINARY_URL_FILENAME_x64="libsoundio-homebrew-linux-amd64-${FEAT_VERSION}.zip"
-			FEAT_BINARY_URL_PROTOCOL_x64="HTTP_ZIP"
-		fi
-		if [ "$STELLA_CURRENT_CPU_FAMILY" = "arm" ]; then
-			FEAT_BINARY_URL_x64="https://github.com/fathyb/libsoundio-homebrew/releases/download/v0.0.3/libsoundio-homebrew.linux-arm64.zip"
-			FEAT_BINARY_URL_FILENAME_x64="libsoundio-homebrew-linux-arm64-${FEAT_VERSION}.zip"
-			FEAT_BINARY_URL_PROTOCOL_x64="HTTP_ZIP"
-		fi
+	if [ "$STELLA_CPU_ARCH" = "64" ]; then
+		FEAT_BINARY_URL_x64="libsoundio"
+		FEAT_BINARY_URL_FILENAME_x64="_AUTO_"
+		FEAT_BINARY_URL_PROTOCOL_x64="HOMEBREW_BOTTLE"
 	fi
 
-	FEAT_INSTALL_TEST="$FEAT_INSTALL_ROOT/libsoundio-homebrew"
-	FEAT_SEARCH_PATH="$FEAT_INSTALL_ROOT"
+	FEAT_INSTALL_TEST="$FEAT_INSTALL_ROOT/lib/pkgconfig/libsoundio.pc"
+	FEAT_SEARCH_PATH="$FEAT_INSTALL_ROOT/bin:$FEAT_INSTALL_ROOT/lib"
 }
 
 feature_libsoundio-homebrew_install_binary() {
 	__get_resource "$FEAT_NAME" "$FEAT_BINARY_URL" "$FEAT_BINARY_URL_PROTOCOL" "$FEAT_INSTALL_ROOT" "DEST_ERASE STRIP FORCE_NAME $FEAT_BINARY_URL_FILENAME"
-	
-	if [ -f "${FEAT_INSTALL_ROOT}/${FEAT_BINARY_URL_FILENAME}" ]; then
-		mv "${FEAT_INSTALL_ROOT}/${FEAT_BINARY_URL_FILENAME}" "${FEAT_INSTALL_ROOT}/libsoundio-homebrew"
-		chmod +x "${FEAT_INSTALL_ROOT}/libsoundio-homebrew"
+
+	local _bottle_payload
+	_bottle_payload=$(find "$FEAT_INSTALL_ROOT" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+	if [ ! "$_bottle_payload" = "" ] && [ ! "$_bottle_payload" = "$FEAT_INSTALL_ROOT" ]; then
+		__copy_folder_content_into "$_bottle_payload" "$FEAT_INSTALL_ROOT"
+		__del_folder "$_bottle_payload"
 	fi
 }
 


### PR DESCRIPTION
## Summary
- use the Homebrew bottle helper when resolving HOMEBREW_BOTTLE resources and add stronger architecture handling
- adjust the bottle download helper to call the artefact script with the correct path and filenames from the cache
- rework the libsoundio-homebrew feature to consume bottles directly and flatten the installation layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f2326aa0832a9fbe929b26785965)