### PR TITLE
feat: add vhs v0.11.0 feature recipe

### DIFF
--- a/nix/pool/feature-recipe/feature_vhs.sh
+++ b/nix/pool/feature-recipe/feature_vhs.sh
@@ -1,0 +1,67 @@
+if [ ! "$_VHS_INCLUDED_" = "1" ]; then
+_VHS_INCLUDED_=1
+
+
+feature_vhs() {
+	FEAT_NAME="vhs"
+	FEAT_LIST_SCHEMA="0_11_0@x64:binary 0_11_0@x86:binary"
+
+	FEAT_DEFAULT_FLAVOUR="binary"
+
+	FEAT_DESC="vhs allows you to write terminal GIFs and asciinema-like videos from a simple script"
+	FEAT_LINK="https://github.com/charmbracelet/vhs https://www.charm.sh"
+}
+
+
+feature_vhs_0_11_0() {
+	FEAT_VERSION="0_11_0"
+
+	if [ "$STELLA_CURRENT_PLATFORM" = "darwin" ]; then
+		if [ "$STELLA_CURRENT_CPU_FAMILY" = "intel" ]; then
+			FEAT_BINARY_URL_x64="https://github.com/charmbracelet/vhs/releases/download/v0.11.0/vhs_0.11.0_Darwin_x86_64.tar.gz"
+			FEAT_BINARY_URL_FILENAME_x64="vhs_0.11.0_Darwin_x86_64.tar.gz"
+			FEAT_BINARY_URL_PROTOCOL_x64="HTTP_ZIP"
+		fi
+		if [ "$STELLA_CURRENT_CPU_FAMILY" = "arm" ]; then
+			FEAT_BINARY_URL_x64="https://github.com/charmbracelet/vhs/releases/download/v0.11.0/vhs_0.11.0_Darwin_arm64.tar.gz"
+			FEAT_BINARY_URL_FILENAME_x64="vhs_0.11.0_Darwin_arm64.tar.gz"
+			FEAT_BINARY_URL_PROTOCOL_x64="HTTP_ZIP"
+		fi
+	fi
+
+	if [ "$STELLA_CURRENT_PLATFORM" = "linux" ]; then
+		if [ "$STELLA_CURRENT_CPU_FAMILY" = "intel" ]; then
+			FEAT_BINARY_URL_x86="https://github.com/charmbracelet/vhs/releases/download/v0.11.0/vhs_0.11.0_Linux_i386.tar.gz"
+			FEAT_BINARY_URL_FILENAME_x86="vhs_0.11.0_Linux_i386.tar.gz"
+			FEAT_BINARY_URL_PROTOCOL_x86="HTTP_ZIP"
+			FEAT_BINARY_URL_x64="https://github.com/charmbracelet/vhs/releases/download/v0.11.0/vhs_0.11.0_Linux_x86_64.tar.gz"
+			FEAT_BINARY_URL_FILENAME_x64="vhs_0.11.0_Linux_x86_64.tar.gz"
+			FEAT_BINARY_URL_PROTOCOL_x64="HTTP_ZIP"
+		fi
+		if [ "$STELLA_CURRENT_CPU_FAMILY" = "arm" ]; then
+			FEAT_BINARY_URL_x86="https://github.com/charmbracelet/vhs/releases/download/v0.11.0/vhs_0.11.0_Linux_arm.tar.gz"
+			FEAT_BINARY_URL_FILENAME_x86="vhs_0.11.0_Linux_arm.tar.gz"
+			FEAT_BINARY_URL_PROTOCOL_x86="HTTP_ZIP"
+			FEAT_BINARY_URL_x64="https://github.com/charmbracelet/vhs/releases/download/v0.11.0/vhs_0.11.0_Linux_arm64.tar.gz"
+			FEAT_BINARY_URL_FILENAME_x64="vhs_0.11.0_Linux_arm64.tar.gz"
+			FEAT_BINARY_URL_PROTOCOL_x64="HTTP_ZIP"
+		fi
+	fi
+
+	FEAT_INSTALL_TEST="${FEAT_INSTALL_ROOT}/vhs"
+	FEAT_SEARCH_PATH="${FEAT_INSTALL_ROOT}"
+}
+
+
+feature_vhs_install_binary() {
+
+	__get_resource "$FEAT_NAME" "$FEAT_BINARY_URL" "$FEAT_BINARY_URL_PROTOCOL" "$FEAT_INSTALL_ROOT" "DEST_ERASE STRIP"
+
+	if [ -f "${FEAT_INSTALL_ROOT}/vhs" ]; then
+		chmod +x "${FEAT_INSTALL_ROOT}/vhs"
+	fi
+
+}
+
+
+fi


### PR DESCRIPTION
### Motivation
- Provide a Stella feature recipe to install `vhs` (Charmbracelet) so users can easily add the `vhs` CLI to their environment using the framework.
- Target the latest upstream release (`v0.11.0`) and provide prebuilt binaries for supported platforms to match existing `binary`-flavour conventions.

### Description
- Adds `nix/pool/feature-recipe/feature_vhs.sh` with an inclusion guard and metadata (`FEAT_NAME`, `FEAT_LIST_SCHEMA`, `FEAT_DESC`, `FEAT_LINK`) and default flavour set to `binary`.
- Defines version function `feature_vhs_0_11_0()` with platform-specific download entries for macOS (`Darwin` x86_64 and arm64) and Linux (i386, x86_64, arm, arm64) using `HTTP_ZIP` protocol and filenames.
- Sets `FEAT_INSTALL_TEST` and `FEAT_SEARCH_PATH` to validate the installed binary location and adds `feature_vhs_install_binary()` which calls `__get_resource` to fetch and extract archives and then sets executable permissions on the `vhs` binary.
- Script follows project conventions (POSIX shell style, variables, naming and install logic consistent with other `binary` features).

### Testing
- Queried the GitHub releases API for `charmbracelet/vhs` using `curl` to confirm latest release `v0.11.0`, which returned expected assets and metadata (succeeded).
- Performed a shell syntax check with `sh -n nix/pool/feature-recipe/feature_vhs.sh` to validate the script syntax (succeeded).
- Created the recipe file `nix/pool/feature-recipe/feature_vhs.sh` and verified its contents match the expected feature structure (file present and validated by the syntax check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6bf8376c4832aabf37609a814c291)